### PR TITLE
infoBar warning rework to pop for alert user

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -126,6 +126,7 @@ import de.berlindroid.zeapp.zeui.zeabout.ZeAbout
 import de.berlindroid.zeapp.zeui.zeopensource.ZeOpenSource
 import de.berlindroid.zeapp.zeui.zetheme.ZeBadgeAppTheme
 import de.berlindroid.zeapp.zeui.zetheme.ZeBlack
+import de.berlindroid.zeapp.zeui.zetheme.ZeCarmine
 import de.berlindroid.zeapp.zeui.zetheme.ZeWhite
 import de.berlindroid.zeapp.zevm.ZeBadgeViewModel
 import de.berlindroid.zeapp.zevm.copy
@@ -630,11 +631,11 @@ private fun InfoBar(
     ZeCard(
         modifier = ZeModifier
             .padding(horizontal = ZeDimen.One, vertical = ZeDimen.One)
-            .background(ZeWhite, ZeRoundedCornerShape(ZeDimen.One))
+            .background(ZeCarmine, ZeRoundedCornerShape(ZeDimen.One))
             .zIndex(10.0f),
         colors = CardDefaults.cardColors(
-            containerColor = ZeWhite,
-            contentColor = ZeBlack,
+            containerColor = ZeCarmine,
+            contentColor = ZeWhite,
         ),
     ) {
         ZeRow(
@@ -645,7 +646,7 @@ private fun InfoBar(
                 modifier = ZeModifier.weight(1.0f),
                 fontSize = 20.sp,
                 fontFamily = FontFamily.Monospace,
-                color = ZeBlack,
+                color = ZeWhite,
                 text = message,
             )
 
@@ -852,6 +853,7 @@ private fun SelectedEditor(
 }
 
 @Composable
+@Preview
 private fun TemplateChooserDialog(
     vm: ZeBadgeViewModel,
     templateChooser: ZeTemplateChooser?,
@@ -890,6 +892,7 @@ private fun TemplateChooserDialog(
 }
 
 @Composable
+@Preview
 @Suppress("LongParameterList")
 private fun PagePreview(
     @PreviewParameter(BinaryBitmapPageProvider::class, 1)


### PR DESCRIPTION
## Summary

Rework the alert info bar to be more visible

## How It Was Tested

1. Go to the side navigation when badge is not connected.
2. Click on any item
3. This will open the alert.

## Screenshot/Gif

![image](https://github.com/gdg-berlin-android/ZeBadge/assets/3008932/a9c74d3f-687a-4ebd-b28a-1de198930be7)


<details>

<summary>Screenshot Name</summary>

<!-- file here -->

</details>